### PR TITLE
Tannon

### DIFF
--- a/archimob/prepare_Archimob_training_files.sh
+++ b/archimob/prepare_Archimob_training_files.sh
@@ -26,15 +26,19 @@ export LC_ALL=C
 scripts_dir=`dirname $0`
 spn_word='<SPOKEN_NOISE>'
 sil_word='<SIL_WORD>'
+transcription='orig'
 
 echo $0 $@
-while getopts 's:n:h' option; do
+while getopts 's:n:t:h' option; do
     case $option in
 	s)
 	    spn_word=${OPTARG}
 	    ;;
 	n)
 	    sil_word=${OPTARG}
+	    ;;
+	t)
+	    transcription=${OPTARG} # allows to select original (orig) or normalised (norm)
 	    ;;
 	h)
 	    echo "$0 [-s '<SPOKEN_NOISE>'] [-n '<SIL_WORD>'] input_csv graphemic_clusters output_dir"
@@ -53,7 +57,7 @@ done
 shift $((OPTIND-1))
 
 if [[ $# -ne 4 ]]; then
-    echo "Wrong call. Should be: $0 [-s '<SPOKEN_NOISE>'] [-n '<SIL_WORD>'] input_csv input_wav_dir graphemic_clusters output_dir"
+    echo "Wrong call. Should be: $0 [-s '<SPOKEN_NOISE>'] [-n '<SIL_WORD>'] [-t 'orig'/'norm'] input_csv input_wav_dir graphemic_clusters output_dir"
     exit 1
 fi
 
@@ -91,14 +95,16 @@ done
 
 mkdir -p $output_dir $tmp_dir $data_dir $ling_dir
 
+echo "Transcription type selected = $transcription..."
+
 ##
 # 1.- Create the transcriptions and wave list:
 # Note the options -f and -p: we are rejecting files with no-relevant-speech or
 # overlapping speech; also, Archimob markers (hesitations, coughing, ...) are
 # mapped to less specific classes (see process_archimob.csv.py)
 echo "Processing $input_csv:"
-# Use -transcr option only when the original input was XML!!
-$scripts_dir/process_archimob_csv.py -i $input_csv -transcr original -f -p \
+# Use -trans option only when the original input was XML!!
+$scripts_dir/process_archimob_csv.py -i $input_csv -trans $transcription -f -p \
                      -t $output_trans -s $spn_word -n $sil_word -o $output_lst
 
 [[ $? -ne 0 ]] && echo 'Error calling process_archimob_csv.py' && exit 1

--- a/archimob/process_archimob_csv.py
+++ b/archimob/process_archimob_csv.py
@@ -48,11 +48,11 @@ def get_args():
     parser.add_argument('--input-csv', '-i', help='Input csv file',
                         required=True)
 
-    parser.add_argument('--type-transcription', '-transcr', help='Define the' \
+    parser.add_argument('--type-transcription', '-trans', help='Define the' \
                         'the preferable type of transcriptions: original' \
-                        '(swiss) or normalizes (german)', type=str,
-                        default='original', nargs='?',
-                        choices=['original', 'normalized'])
+                        '(swiss) or normalized (~german)', type=str,
+                        default='orig', nargs='?',
+                        choices=['orig', 'norm'])
 
     parser.add_argument('--do-filtering', '-f', help='If given, exclude ' \
                         'utterances marked with no-relevant-speech or ' \
@@ -348,7 +348,7 @@ def main():
         #     continue
 
         # Check filtering:
-        if args.type_transcription in ['original', 'normalized']:
+        if args.type_transcription in ['orig', 'norm']:
             if args.do_filtering or args.test_mode:
                 if int(data_dict['anonymity']) == 1 or \
                    int(data_dict['speech_in_speech']) == 1 or \
@@ -392,7 +392,7 @@ def main():
                         'word)'.format(data_dict['utt_id'])
                 continue
 
-        if args.type_transcription == 'original':
+        if args.type_transcription == 'orig':
             if args.do_processing:
                 # Process text:
                 transcription = process_transcription(data_dict['transcription'],
@@ -402,7 +402,7 @@ def main():
                 # do this...
                 transcription = data_dict['transcription']
 
-        if args.type_transcription == 'normalized':
+        if args.type_transcription == 'norm':
             transcription = data_dict['normalized']
 
         # Write the transcriptions file:

--- a/archimob/split_data.py
+++ b/archimob/split_data.py
@@ -75,11 +75,10 @@ def main():
 
     outfiles = []
 
-    if args.train:
-        train_file = args.outpath+'/'+'train.csv'
-        train_file_handle = open(train_file, 'w', encoding='utf8')
-        train_file_writer = csv.writer(train_file_handle)
-        outfiles.append(train_file_handle)
+    train_file = args.outpath+'/'+'train.csv'
+    train_file_handle = open(train_file, 'w', encoding='utf8')
+    train_file_writer = csv.writer(train_file_handle)
+    outfiles.append(train_file_handle)
 
     if args.test:
         test_file = args.outpath+'/'+'test.csv'
@@ -108,7 +107,8 @@ def main():
 
         # write headers
         train_file_writer.writerow(col_names)
-        test_file_writer.writerow(col_names)
+        if args.test:
+            test_file_writer.writerow(col_names)
         if args.dev:
             dev_file_writer.writerow(col_names)
 

--- a/conf/mfcc.conf
+++ b/conf/mfcc.conf
@@ -1,2 +1,3 @@
 --use-energy=false   # only non-default option.
 --sample-frequency=8000
+--allow_downsample=true

--- a/train_AM.sh
+++ b/train_AM.sh
@@ -21,7 +21,7 @@ set -u
 #                  generated with process_exmaralda_xml.py)
 #     * output_dir: folder to write the output files to
 #
-# 
+#
 #
 
 ################
@@ -41,6 +41,14 @@ num_gaussians=10000  # Number of Gaussians for the triphone stage
 # recomputing again all the stages from the very beginning.
 do_archimob_preparation=1
 do_data_preparation=1
+# ## for testing
+# do_feature_extraction=0
+# do_train_monophone=0
+# do_train_triphone=0
+# do_train_triphone_lda=0
+# do_train_mmi=0
+# do_nnet2=0
+# do_nnet2_discriminative=0
 do_feature_extraction=1
 do_train_monophone=1
 do_train_triphone=1
@@ -59,8 +67,8 @@ do_nnet2_discriminative=1
 . utils/parse_options.sh
 
 echo $0 $@
-if [[ $# -ne 3 ]]; then
-    echo "Wrong call. Should be: $0 input_csv input_wav output_dir"
+if [[ $# -lt 3 ]]; then
+    echo "Wrong call. Should be: $0 input_csv input_wav output_dir transcription"
     exit 1
 fi
 
@@ -70,6 +78,13 @@ fi
 input_csv=$1
 input_wav_dir=$2
 output_dir=$3
+transcription=${4:-orig}
+
+if [ $transcription != "orig" ] && [ $transcription != "norm" ]; then
+    echo "$transcription is an invalid transcription type."
+    echo "Transcription type must be either 'orig' (default) or 'norm'."
+    exit 1
+fi
 
 ###############
 # Intermediate:
@@ -101,7 +116,7 @@ mkdir -p $output_dir
 if [[ $do_archimob_preparation -ne 0 ]]; then
 
     archimob/prepare_Archimob_training_files.sh -s "$SPOKEN_NOISE_WORD" \
-						-n "$SIL_WORD" \
+						-n "$SIL_WORD" -t $transcription \
 						$input_csv $input_wav_dir \
 						$GRAPHEMIC_CLUSTERS \
 						$initial_data
@@ -109,6 +124,7 @@ if [[ $do_archimob_preparation -ne 0 ]]; then
     [[ $? -ne 0 ]] && echo 'Error preparing Archimob training files' && exit 1
 
 fi
+
 
 # From this moment on, all the data is organized the way Kaldi likes
 
@@ -252,4 +268,3 @@ if [[ $do_nnet2_discriminative -ne 0 ]]; then
 fi
 
 echo "Done: $0"
-


### PR DESCRIPTION
Changes:

Training:
- `train_AM.sh`: now accepts an extra parameter from command line to specify processing of 'original' transcriptions (Dieth) or 'normalised' transcriptions.
- `archimob/process_archimob_csv.py`: arguments changed to support this functionality.
- `archimob/prepare_Archimob_training_files.sh`: arguments changes to support this functionality.
- `mfcc.conf`: set variable to allow downsampling to true.

Data prep:
- `archimob/split_data.py`: now accepts training utterances specified in a JSON file. This is useful for recreating the 'baseline' training set according to utterances used in Fran's original evaluation which draw from archimob r1. If no training utterance JSON is supplied, it writes all utterances not listed in the test or dev lists to the output training file. This makes it easy to recreate these test sets from a given csv file.


