### PR TITLE
Multiple decoding for the same AMs

### DIFF
--- a/decode_nnet_ad.sh
+++ b/decode_nnet_ad.sh
@@ -51,7 +51,8 @@ transcription=${6:-orig}
 ###############
 # Intermediate:
 ###############
-kaldi_output_dir="$model_dir/decode"
+# kaldi_output_dir="$model_dir/decode"
+kaldi_output_dir="$output_dir/decode" # output dir for decoding is not in decode_out/ instead of model dir
 tmp_dir="$output_dir/tmp"
 lang_dir="$output_dir/lang"
 wav_lst="$tmp_dir/wav.lst"
@@ -79,7 +80,7 @@ output_lst="$tmp_dir/wav.lst"
 # # This parses any input option, if supplied.
 # . utils/parse_options.sh
 
-mkdir -p $kaldi_output_dir $output_dir $lang_dir $tmp_dir
+mkdir -p $output_dir $kaldi_output_dir $lang_dir $tmp_dir
 
 ##
 # 1.- Create the transcriptions and wave list:
@@ -128,7 +129,7 @@ if [[ $do_decoding -ne 0 ]]; then
 
     rm -rf $kaldi_output_dir/*
     uzh/decode.sh --cmd "$decode_cmd" --nj $num_jobs $graph_dir \
-        $lang_dir $kaldi_output_dir
+        $lang_dir $kaldi_output_dir $model_dir
 
     [[ $? -ne 0 ]] && echo 'Error decoding' && exit 1
 

--- a/uzh/decode.sh
+++ b/uzh/decode.sh
@@ -32,8 +32,8 @@ echo "$0 $@"  # Print the command line for logging
 [ -f ./path.sh ] && . ./path.sh; # source the path.
 . parse_options.sh || exit 1;
 
-if [ $# -ne 3 ]; then
-  echo "Usage: $0 [options] <graph-dir> <data-dir> <decode-dir>"
+if [ $# -ne 4 ]; then
+  echo "Usage: $0 [options] <graph-dir> <data-dir> <decode-dir> <model-dir>"
   echo " e.g.: $0 --transform-dir exp/tri3b/decode_dev93_tgpr \\"
   echo "      exp/tri3b/graph_tgpr data/test_dev93 exp/tri4a_nnet/decode_dev93_tgpr"
   echo "main options (for others, see top of script file)"
@@ -53,7 +53,8 @@ fi
 graphdir=$1
 data=$2
 dir=$3
-srcdir=`dirname $dir`; # Assume model directory one level up from decoding directory.
+# srcdir=`dirname $dir`; # Assume model directory one level up from decoding directory.
+srcdir=$4 # specify model directory explicitly to allow decoding to be written to decode out directory
 model=$srcdir/$iter.mdl
 
 


### PR DESCRIPTION
`decode_nnet_ad.sh` now sends decoding output to the specified output directory rather than the models directory.

Previously it was assumed that the decode directory was one level up from the models directory. Now the decode directory is passed explicitly to `uzh/decode.sh` so that you can have different decodings for the same acoustic model. This is useful if you want to compare the performance of a new language model against a baseline.

The arguments for `decode_nnet_ad.sh` remain unchanged.